### PR TITLE
fix: cleanup vitest config to include only sources in coverage

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,31 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import path from 'node:path';
-
 /**
- * Config for global end-to-end tests
- * placed in project root tests folder
+ * Config for tests
  * @type {import('vite').UserConfig}
  * @see https://vitest.dev/config/
  */
 const config = {
   test: {
     globals: true,
-    include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    exclude: ['**/builtin/**',
-      '**/node_modules/**',
-      '**/dist/**',
-    ],
-    /**
-     * A default timeout of 5000ms is sometimes not enough for playwright.
-     */
-    testTimeout: 60_000,
-    hookTimeout: 60_000,
+    coverage: {
+      include: ['**/*.ts'],
+    },
   },
   resolve: {
     alias: {
-      '@podman-desktop/api': path.resolve(__dirname, '__mocks__/@podman-desktop/api.js'),
+      '@podman-desktop/api': `${__dirname}/__mocks__/@podman-desktop/api.js`,
     },
   },
 };


### PR DESCRIPTION
This fix removes scripts and __mocks__ files from code coverage report.
The report goes from one includes __mocks__ and scripts

```
vitest run --coverage

 RUN  v1.6.0 /home/runner/work/podman-desktop-sandbox-ext/podman-desktop-sandbox-ext
      Coverage enabled with v8

Config file location /usr/home/test
Default context => false

 ✓ src/extension.spec.ts  (6 tests) 22ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  04:01:18
   Duration  875ms (transform 77ms, setup 0ms, collect 575ms, tests 22ms, environment 0ms, prepare 79ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   56.65 |       80 |   42.85 |   56.65 |                   
 ...podman-desktop |   90.56 |      100 |      50 |   90.56 |                   
  api.js           |   90.56 |      100 |      50 |   90.56 | 27-31             
 scripts           |       0 |        0 |       0 |       0 |                   
  build.js         |       0 |        0 |       0 |       0 | 1-63              
 src               |    60.2 |    82.14 |   44.44 |    60.2 |                   
  extension.ts     |   63.18 |    84.61 |      50 |   63.18 | ...67-368,375-381 
  kubeconfig.ts    |      75 |       50 |      50 |      75 | 27-28,33-40       
-------------------|---------|----------|---------|---------|-------------------
Done in 1.45s.

```

to one that does not

```
Run yarn test
yarn run v1.22.22
warning redhat-sandbox@0.0.4: The engine "podman-desktop" appears to be invalid.
$ vitest run --coverage

 RUN  v1.6.0 /home/runner/work/podman-desktop-sandbox-ext/podman-desktop-sandbox-ext
      Coverage enabled with v8

stdout | src/extension.spec.ts > kubernetes provider connection factory is set during activation
starting extension openshift-sandbox
Config file location /usr/home/test

 ✓ src/extension.spec.ts  (1 test) 4ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  18:53:02
   Duration  842ms (transform 69ms, setup 0ms, collect 567ms, tests 4ms, environment 0ms, prepare 83ms)

 % Coverage report from v8
---------------|---------|----------|---------|---------|-----------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s     
---------------|---------|----------|---------|---------|-----------------------
All files      |   38.28 |     62.5 |      25 |   38.28 |                       
 extension.ts  |   34.93 |    66.66 |   21.42 |   34.93 | ...11,416-425,427-438 
 kubeconfig.ts |      75 |       50 |      50 |      75 | 27-28,33-40           
---------------|---------|----------|---------|---------|-----------------------
Done in 1.41s.
```

