### PR TITLE
fix: remove node_modules from extension images

### DIFF
--- a/.extfiles
+++ b/.extfiles
@@ -1,5 +1,4 @@
 dist/**
-node_modules/**
 icon.png
 LICENSE
 package.json


### PR DESCRIPTION
node-modules is not needed, because kubernetes-client module now included into dist/extebsuib.cjs during the build.
This makes build run much 10 times faster and image size much smaller down to 983.8 KiB from 218.6 MiB.

