### PR TITLE
fix: update url to Developer Sandbox start page

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,7 +195,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionApi.commands.registerCommand('sandbox.open.login.url', () => {
       extensionApi.env
         .openExternal(
-          extensionApi.Uri.parse('https://developers.redhat.com/developer-sandbox/?sc_cid=7013a000003SUmgAAG'),
+          extensionApi.Uri.parse('https://console.redhat.com/openshift/sandbox?sc_cid=7013a000003SUmgAAG'),
         )
         .then(successful => {
           TelemetryLogger.logUsage('sandboxOpenLoginUrlRequest', { successful });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,9 +194,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   extensionContext.subscriptions.push(
     extensionApi.commands.registerCommand('sandbox.open.login.url', () => {
       extensionApi.env
-        .openExternal(
-          extensionApi.Uri.parse('https://console.redhat.com/openshift/sandbox?sc_cid=7013a000003SUmgAAG'),
-        )
+        .openExternal(extensionApi.Uri.parse('https://console.redhat.com/openshift/sandbox?sc_cid=7013a000003SUmgAAG'))
         .then(successful => {
           TelemetryLogger.logUsage('sandboxOpenLoginUrlRequest', { successful });
         });


### PR DESCRIPTION
New URL leads directly to the page where it can be started.

![image](https://github.com/user-attachments/assets/775c7a62-3759-4195-948f-8b8bcfb61e47)

Fix #361.
