### PR TITLE
fix: fix got module type definition resolution error

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -20,13 +20,13 @@
 
 import { beforeEach, expect, Mock, suite, test, vi } from 'vitest';
 import * as podmanDesktopApi from '@podman-desktop/api';
-import * as extension from './extension';
+import * as extension from './extension.js';
 import { URI } from 'vscode-uri';
-import * as openshift from './openshift';
-import * as kubeconfig from './kubeconfig';
+import * as openshift from './openshift.js';
+import * as kubeconfig from './kubeconfig.js';
 import { KubeConfig } from '@kubernetes/client-node';
 
-const getKubeconfigMock = podmanDesktopApi.kubernetes.getKubeconfig as unknown as Mock<any>;
+const getKubeconfigMock = vi.mocked(podmanDesktopApi.kubernetes.getKubeconfig);
 getKubeconfigMock.mockReturnValue(URI.parse('file:///usr/home/test'));
 
 const context: podmanDesktopApi.ExtensionContext = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,8 +19,8 @@
 import { KubeConfig } from '@kubernetes/client-node';
 import * as extensionApi from '@podman-desktop/api';
 import got from 'got';
-import * as kubeconfig from './kubeconfig';
-import { getOpenShiftInternalRegistryPublicHost, whoami } from './openshift';
+import * as kubeconfig from './kubeconfig.js';
+import { getOpenShiftInternalRegistryPublicHost, whoami } from './openshift.js';
 
 const ProvideDisplayName = 'Developer Sandbox';
 

--- a/src/openshift.ts
+++ b/src/openshift.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import got from 'got';
-import * as kubeconfig from './kubeconfig';
+import * as kubeconfig from './kubeconfig.js';
 import * as extensionApi from '@podman-desktop/api';
 
 export interface InternalRegistryInfo {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "types": [ "node" ],
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": [ "ES2017", "webworker" ],
-    "module": "ESNext",
+    "module": "NodeNext",
     "target": "ESNext",
     "sourceMap": true,
     "rootDir": "src",


### PR DESCRIPTION
Fix error reported by tsc in vscode.

![image](https://github.com/user-attachments/assets/dd1a75cd-9356-402b-8933-91b78f7bdda8)

```
src/extension.ts:21:17 - error TS2307: Cannot find module 'got' or its corresponding type declarations.
  There are types at '/Users/eskimo/Sources/sandbox/node_modules/got/dist/source/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

21 import got from 'got';
                   ~~~~~
```