### PR TITLE
feat: add Containerfiles for build

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ghcr.io/redhat-developer/podman-desktop-sandbox-ext-builder:next as builder
+
+COPY --chown=1001:root . .
+RUN yarn install && yarn build
+
+FROM scratch
+
+LABEL org.opencontainers.image.title="Developer Sandbox Provider" \
+        org.opencontainers.image.description="Developer Sandbox provider for Podman Desktop" \
+        org.opencontainers.image.vendor="Red Hat" \
+        io.podman-desktop.api.version=">= 0.14.1"
+
+COPY --from=builder /opt/app-root/extension-source/builtin/redhat-sandbox.cdix /extension

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM registry.access.redhat.com/ubi10/nodejs-22-minimal@sha256:52f5a9e3eb1191276ef576ad88142a27d4ef61317384f383534526f55761387b
+
+ENV EXTENSION_SRC=/opt/app-root/extension-source
+RUN mkdir -p $EXTENSION_SRC
+WORKDIR $EXTENSION_SRC
+
+COPY yarn.lock package.json .
+RUN npm install --global yarn && \
+    yarn --frozen-lockfile install


### PR DESCRIPTION
PR provides Containerfiles to build extension.

Fix #746. 

How to use from podman-desktop-sandbox-ext folder:

1. `$ podman build . -f build/Containerfile.builder -t ghcr.io/redhat-developer/podman-desktop-sandbox-ext-builder:next`
2. `$ podman build . -f build/Containerfile -t ghcr.io/redhat-developer/podman-desktop-sandbox-ext:next`
3. `$ podman create --name extension-sandbox ghcr.io/redhat-developer/podman-desktop-sandbox-ext:next`
4. `$ mkdir tmp`
5. `$ podman cp extension-sandbox:/extension tmp`

How to check results:

```
ls -l tmp/extension tmp/extension/dist
tmp/extension:
total 72
-rw-r--r--@ 1 username  staff  11358 Dec  5 11:25 LICENSE
-rw-r--r--@ 1 username  staff   5962 Dec  5 11:25 README.md
drwxr-xr-x@ 3 username  staff     96 Dec  5 11:25 dist
-rw-r--r--@ 1 username  staff   7205 Dec  5 11:25 icon.png
-rw-r--r--@ 1 username  staff   3657 Dec  5 11:25 package.json
-rw-r--r--@ 1 username  staff    704 Dec  5 11:25 sandbox-icon.woff2

tmp/extension/dist:
total 47272
-rw-r--r--@ 1 username  staff  24199786 Dec  5 11:25 extension.cjs
```
