### PR TITLE
fix: set development version to 0.0.7 before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
   "displayName": "Developer Sandbox",
   "description": "Sign up and provisioning for Developer Sandbox",
-  "version": "0.0.6",
+  "version": "0.0.7-next",
   "icon": "icon.png",
   "publisher": "redhat",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
   "displayName": "Developer Sandbox",
   "description": "Sign up and provisioning for Developer Sandbox",
-  "version": "0.0.7-next",
+  "version": "0.0.7",
   "icon": "icon.png",
   "publisher": "redhat",
   "license": "Apache-2.0",


### PR DESCRIPTION
PR sets development version using ${next-ver-to-release}-next to work correctly with release.yaml when it is going to do tagging and upversioning.