### PR TITLE
Revert "build(deps): bump pnpm/action-setup from 5.0.0 to 6.0.0 (#828)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -84,7 +84,7 @@ jobs:
           ref: main
           path: podman-desktop
 
-      - uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v4.1.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.1.0
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false
@@ -145,7 +145,7 @@ jobs:
           ref: main
           path: podman-desktop
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: pnpm/action-setup@v6.0.1
+      - uses: pnpm/action-setup@v5.0.0
         name: Install pnpm
         with:
           run_install: false


### PR DESCRIPTION
This reverts commit d841ffb9006df6512c6f7414f6cc968fc37ef6b6 to avoid https://github.com/pnpm/action-setup/issues/228 issue.