### PR TITLE
fix: resolve CVE-2026-48779 in ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
       "ip-address": "^10.1.1",
       "minimatch@<3.1.3": "^3.1.3",
       "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "ws": ">=8.21.0"
     }
   },
   "extensionDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   minimatch@<3.1.3: ^3.1.3
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
   esbuild: '>=0.28.1'
+  ws: '>=8.21.0'
 
 importers:
 
@@ -773,7 +774,7 @@ packages:
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.21.0'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1353,8 +1354,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1504,7 +1505,7 @@ snapshots:
       '@types/stream-buffers': 3.0.8
       form-data: 4.0.5
       hpagent: 1.2.0
-      isomorphic-ws: 5.0.0(ws@8.20.1)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       js-yaml: 4.2.0
       jsonpath-plus: 10.3.0
       node-fetch: 2.7.0
@@ -1513,7 +1514,7 @@ snapshots:
       socks-proxy-agent: 8.0.5
       stream-buffers: 3.0.3
       tar-fs: 3.1.1
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -2040,9 +2041,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.20.1):
+  isomorphic-ws@5.0.0(ws@8.21.0):
     dependencies:
-      ws: 8.20.1
+      ws: 8.21.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2557,7 +2558,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-48779 in `ws`.

**Advisory**: ws: Memory exhaustion DoS from tiny fragments and data chunks
**Vulnerable versions**: >=8.0.0 <8.21.0
**Patched versions**: >=8.21.0
**Advisory URL**: https://github.com/advisories/GHSA-96hv-2xvq-fx4p

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-48779: _ws: Memory exhaustion DoS from tiny fragments and data chunks_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-48779 is no longer reported