### PR TITLE
fix: resolve CVE-2026-12143 in form-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
       "minimatch@<3.1.3": "^3.1.3",
       "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
       "esbuild": ">=0.28.1",
-      "ws": ">=8.21.0"
+      "ws": ">=8.21.0",
+      "form-data": ">=4.0.6"
     }
   },
   "extensionDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
   esbuild: '>=0.28.1'
   ws: '>=8.21.0'
+  form-data: '>=4.0.6'
 
 importers:
 
@@ -651,8 +652,8 @@ packages:
       picomatch:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@11.3.5:
@@ -718,8 +719,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hpagent@1.2.0:
@@ -1503,7 +1504,7 @@ snapshots:
       '@types/node': 24.10.1
       '@types/node-fetch': 2.6.13
       '@types/stream-buffers': 3.0.8
-      form-data: 4.0.5
+      form-data: 4.0.6
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
       js-yaml: 4.2.0
@@ -1628,7 +1629,7 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 24.10.1
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/node@24.10.1':
     dependencies:
@@ -1892,7 +1893,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   escalade@3.2.0: {}
 
@@ -1914,12 +1915,12 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-extra@11.3.5:
@@ -1950,7 +1951,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -1999,7 +2000,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-12143 in `form-data`.

**Advisory**: form-data: CRLF injection in form-data via unescaped multipart field names and filenames
**Vulnerable versions**: >=4.0.0 <4.0.6
**Patched versions**: >=4.0.6
**Advisory URL**: https://github.com/advisories/GHSA-hmw2-7cc7-3qxx

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-12143: _form-data: CRLF injection in form-data via unescaped multipart field names and filenames_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-12143 is no longer reported