### PR TITLE
fix: resolve CVE-2026-33750 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
       "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
       "esbuild": ">=0.28.1",
       "ws": ">=8.21.0",
-      "form-data": ">=4.0.6"
+      "form-data": ">=4.0.6",
+      "brace-expansion@<1.1.13": ">=1.1.13 <2"
     }
   },
   "extensionDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   esbuild: '>=0.28.1'
   ws: '>=8.21.0'
   form-data: '>=4.0.6'
+  brace-expansion@<1.1.13: '>=1.1.13 <2'
 
 importers:
 
@@ -486,8 +487,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
@@ -1761,7 +1762,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -2194,7 +2195,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.15
 
   mkdirp@1.0.4: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-33750 in `brace-expansion`.

**Advisory**: brace-expansion: Zero-step sequence causes process hang and memory exhaustion
**Vulnerable versions**: <1.1.13
**Patched versions**: >=1.1.13
**Advisory URL**: https://github.com/advisories/GHSA-f886-m6hf-6m8v

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33750: _brace-expansion: Zero-step sequence causes process hang and memory exhaustion_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33750 is no longer reported