### PR TITLE
fix: resolve CVE-2026-9697 in undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
       "esbuild": ">=0.28.1",
       "ws": ">=8.21.0",
       "form-data": ">=4.0.6",
-      "brace-expansion@<1.1.13": ">=1.1.13 <2"
+      "brace-expansion@<1.1.13": ">=1.1.13 <2",
+      "undici": "^7.28.0"
     }
   },
   "extensionDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   ws: '>=8.21.0'
   form-data: '>=4.0.6'
   brace-expansion@<1.1.13: '>=1.1.13 <2'
+  undici: ^7.28.0
 
 importers:
 
@@ -1211,8 +1212,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   universalify@2.0.1:
@@ -2085,7 +2086,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -2466,7 +2467,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   universalify@2.0.1: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-9697 in `undici`.

**Advisory**: undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent
**Vulnerable versions**: >=7.23.0 <7.28.0
**Patched versions**: >=7.28.0
**Advisory URL**: https://github.com/advisories/GHSA-vmh5-mc38-953g

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-9697: _undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-9697 is no longer reported