### PR TITLE
fix: use the same scopes for auth session as other extensions

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -145,6 +145,22 @@ suite('kubernetes provider connection factory', () => {
     expect(verificationError?.message).is.equal('Context name is required.');
   });
 
+  test('requests authentication session with required scopes', async () => {
+    const config = new KubeConfig();
+    await callCreate(
+      {
+        'redhat.sandbox.context.name': 'contextName',
+        'redhat.sandbox.context.default': true,
+      },
+      config,
+    );
+    expect(podmanDesktopApi.authentication.getSession).toHaveBeenCalledWith(
+      'redhat.authentication-provider',
+      extension.AuthenticationScopes,
+      { createIfNone: true },
+    );
+  });
+
   test('creates new context for sandbox with specified url/token and sets it as default context', async () => {
     const config = new KubeConfig();
     await callCreate(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,8 @@ let registeredConnections: Map<string, ConnectionData> = new Map<string, Connect
 
 type ImageInfo = { engineId: string; name?: string; tag?: string };
 
+export const AuthenticationScopes = ['api.iam.registry_service_accounts', 'api.console'];
+
 export async function pushImageToOpenShiftRegistry(image: ImageInfo): Promise<void> {
   const qp = Array.from(registeredConnections.values())
     .filter(connection => connection.status === 'started')
@@ -286,9 +288,13 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       }
 
       // use existing SSO session or request to login
-      const ssoSession = await extensionApi.authentication.getSession('redhat.authentication-provider', ['openid'], {
-        createIfNone: true,
-      });
+      const ssoSession = await extensionApi.authentication.getSession(
+        'redhat.authentication-provider',
+        AuthenticationScopes,
+        {
+          createIfNone: true,
+        },
+      );
 
       // check Developer Sandbox status and sign up for it if possible
       let status: SBSignupResponse = await getDevSandboxSignUpStatus((ssoSession as any).idToken);


### PR DESCRIPTION
Related to #773.

Red Hat SSO authentication provider matches existing sessions with exactly the same scopes. Sandbox should use the same scopes as [Red Hat SSO extension ](https://github.com/redhat-developer/podman-desktop-redhat-account-ext/blob/dc863625213fc9f8c4011f6fe9493a786530a442/src/util.ts#L41)to avoid triggering authentication dialog when there is already  session created by Red Hat SSO Authentication provider triggered from different Red Hat extension.