### PR TITLE
fix: use auditor to verify resource form values before submitting it

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -85,6 +85,45 @@ test('kubernetes provider connection factory is set during activation', async ()
   expect(providerMock.setKubernetesProviderConnectionFactory).toBeCalled();
 });
 
+describe('connectionAuditor', () => {
+  test('returns error when context name is not provided', async () => {
+    const result = await extension.connectionAuditor({});
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].type).toBe('error');
+    expect(result.records[0].record).toBe('Context name is required.');
+  });
+
+  test('returns error when context name already exists in kubeconfig', async () => {
+    const config = new KubeConfig();
+    config.loadFromOptions({
+      contexts: [{ cluster: 'cluster', name: 'existingContext', user: 'user' }],
+      clusters: [{ name: 'cluster', server: 'https://server' }],
+      users: [{ name: 'user', token: 'token' }],
+    });
+    vi.spyOn(kubeconfig, 'createOrLoadFromFile').mockReturnValue(config);
+    const result = await extension.connectionAuditor({
+      [extension.ContextNameParam]: 'existingContext',
+    });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].type).toBe('error');
+    expect(result.records[0].record).toBe('Context existingContext already exists, please choose a different name.');
+  });
+
+  test('returns no errors when context name is valid and unique', async () => {
+    const config = new KubeConfig();
+    config.loadFromOptions({
+      contexts: [],
+      clusters: [],
+      users: [],
+    });
+    vi.spyOn(kubeconfig, 'createOrLoadFromFile').mockReturnValue(config);
+    const result = await extension.connectionAuditor({
+      [extension.ContextNameParam]: 'newContext',
+    });
+    expect(result.records).toHaveLength(0);
+  });
+});
+
 suite('kubernetes provider connection factory', () => {
   async function callCreate(
     params: { [key: string]: any } = {},
@@ -137,13 +176,6 @@ suite('kubernetes provider connection factory', () => {
       provider: providerMock,
     };
   }
-
-  test('verifies context name is entered', async () => {
-    const { error: verificationError } = await callCreate();
-
-    expect(verificationError).toBeDefined();
-    expect(verificationError?.message).is.equal('Context name is required.');
-  });
 
   test('requests authentication session with required scopes', async () => {
     const config = new KubeConfig();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { KubeConfig } from '@kubernetes/client-node';
+import type { AuditRequestItems, AuditResult } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import got from 'got';
 import * as kubeconfig from './kubeconfig.js';
@@ -239,6 +240,30 @@ export async function getDevSandboxSignUpStatus(idToken: string): Promise<SBSign
 
 let deactivated = false; // flag to prevent setting timeout after deactivation
 
+let cachedKubeconfig: KubeConfig | undefined; // cache to avoid loading kubeconfig file multiple times in auditor
+
+export async function connectionAuditor(items: AuditRequestItems): Promise<AuditResult> {
+  const records: extensionApi.AuditRecord[] = [];
+
+  const contextName = items[ContextNameParam];
+  if (!contextName) {
+    records.push({
+      type: 'error',
+      record: 'Context name is required.',
+    });
+  } else {
+    const config = cachedKubeconfig ?? kubeconfig.createOrLoadFromFile(extensionApi.kubernetes.getKubeconfig().fsPath);
+    if (config['contexts'].find(context => context['name'] === contextName)) {
+      records.push({
+        type: 'error',
+        record: `Context ${contextName} already exists, please choose a different name.`,
+      });
+    }
+  }
+
+  return { records };
+}
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   console.log('starting extension redhat-developer-sandbox');
   deactivated = false; // reset for tests to work correctly
@@ -281,74 +306,70 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const kubeconfigFile = kubeconfigUri.fsPath;
   console.log('Config file location', kubeconfigFile);
 
-  const disposable = provider.setKubernetesProviderConnectionFactory({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create: async (
-      params: { [key: string]: any },
-      _logger?: extensionApi.Logger,
-      _token?: extensionApi.CancellationToken,
-    ) => {
-      // check if context name is provided
-      if (!params[ContextNameParam]) {
-        throw new Error('Context name is required.');
-      }
+  const disposable = provider.setKubernetesProviderConnectionFactory(
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      create: async (
+        params: { [key: string]: any },
+        _logger?: extensionApi.Logger,
+        _token?: extensionApi.CancellationToken,
+      ) => {
+        try {
+          const config = kubeconfig.createOrLoadFromFile(extensionApi.kubernetes.getKubeconfig().fsPath);
 
-      // first verify context name does not exists yet in kubeconfig
-      const config = kubeconfig.createOrLoadFromFile(extensionApi.kubernetes.getKubeconfig().fsPath);
+          // use existing SSO session or request to login
+          const ssoSession = await extensionApi.authentication.getSession(
+            'redhat.authentication-provider',
+            AuthenticationScopes,
+            {
+              createIfNone: true,
+            },
+          );
+          let status: SBSignupResponse = await getDevSandboxSignUpStatus((ssoSession as any).idToken);
+          const token = await getPipelineServiceAccountToken(
+            status.proxyURL,
+            status.compliantUsername,
+            (ssoSession as any).idToken,
+          );
 
-      if (config['contexts'].find(context => context['name'] === params[ContextNameParam])) {
-        throw new Error(`Context ${params[ContextNameParam]} already exists, please choose a different name.`);
-      }
+          const suffix = Math.random().toString(36).substring(7);
+          const clusterName = `sandbox-cluster-${suffix}`;
+          const userName = `sandbox-user-${suffix}`;
 
-      // use existing SSO session or request to login
-      const ssoSession = await extensionApi.authentication.getSession(
-        'redhat.authentication-provider',
-        AuthenticationScopes,
-        {
-          createIfNone: true,
-        },
-      );
+          config.addCluster({
+            server: status.apiEndpoint,
+            name: clusterName,
+            skipTLSVerify: false,
+          });
+          config.addUser({
+            name: userName,
+            token,
+          });
+          config.addContext({
+            cluster: clusterName,
+            user: userName,
+            name: params[ContextNameParam],
+            namespace: `${status.compliantUsername}-dev`,
+          });
+          if (params[DefaultContextParam]) {
+            config.setCurrentContext(params[ContextNameParam]);
+          }
 
-      // check Developer Sandbox status and sign up for it if possible
-      let status: SBSignupResponse = await getDevSandboxSignUpStatus((ssoSession as any).idToken);
+          kubeconfig.exportToFile(config, kubeconfigFile);
 
-      // get pipeline service account token or create new one
-      const token = await getPipelineServiceAccountToken(
-        status.proxyURL,
-        status.compliantUsername,
-        (ssoSession as any).idToken,
-      );
-
-      const suffix = Math.random().toString(36).substring(7);
-
-      const clusterName = `sandbox-cluster-${suffix}`; // has unique name
-      const userName = `sandbox-user-${suffix}`; // generate a unique name for the user
-
-      config.addCluster({
-        server: status.apiEndpoint,
-        name: clusterName,
-        skipTLSVerify: false,
-      });
-      config.addUser({
-        name: userName,
-        token,
-      });
-      config.addContext({
-        cluster: clusterName,
-        user: userName,
-        name: params[ContextNameParam],
-        namespace: `${status.compliantUsername}-dev`,
-      });
-      if (params[DefaultContextParam]) {
-        config.setCurrentContext(params[ContextNameParam]);
-      }
-
-      kubeconfig.exportToFile(config, kubeconfigFile);
-
-      await registerConnection(params[ContextNameParam], status.apiEndpoint, token);
+          await registerConnection(params[ContextNameParam], status.apiEndpoint, token);
+        } finally {
+          cachedKubeconfig = undefined;
+        }
+      },
+      creationDisplayName: ProvideDisplayName,
     },
-    creationDisplayName: ProvideDisplayName,
-  });
+    {
+      auditItems: async (items: AuditRequestItems) => {
+        return await connectionAuditor(items);
+      },
+    },
+  );
 
   extensionContext.subscriptions.push(
     extensionApi.commands.registerCommand('sandbox.image.push.to.cluster', image => {


### PR DESCRIPTION
Fix #676.

PR introduces connection auditor that verifies form values after every change and enables/disables create button depending on result of validation.

Before this PR

https://github.com/user-attachments/assets/fba5db07-2948-412e-b2f4-0a4c38068458

and after.

https://github.com/user-attachments/assets/4d2b5a49-cb43-4cf6-ae81-cdf0878846d5

Assisted-by: <Cursor>