### PR TITLE
fix: don't set timer for refreshing connection status after deactivation

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -399,6 +399,48 @@ suite('kubernetes provider connection factory', () => {
   });
 });
 
+describe('deactivation stops periodic connection updates', () => {
+  function setupActivation(): podmanDesktopApi.Provider {
+    const providerMock: podmanDesktopApi.Provider = {
+      setKubernetesProviderConnectionFactory: vi.fn(),
+      registerKubernetesProviderConnection: () => ({
+        dispose: vi.fn(),
+      }),
+    } as any as podmanDesktopApi.Provider;
+    vi.spyOn(podmanDesktopApi.provider, 'createProvider').mockReturnValue(providerMock);
+    vi.spyOn(kubeconfig, 'createOrLoadFromFile').mockReturnValue(new KubeConfig());
+    return providerMock;
+  }
+
+  test('clearTimeout is called when deactivate is invoked', async () => {
+    setupActivation();
+    await extension.activate(context);
+
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+    extension.deactivate();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  test('updateConnections is not called again after deactivate', async () => {
+    vi.useFakeTimers();
+    setupActivation();
+    await extension.activate(context);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    const createOrLoadSpy = vi.mocked(kubeconfig.createOrLoadFromFile);
+    createOrLoadSpy.mockClear();
+
+    extension.deactivate();
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(createOrLoadSpy).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+
 test('push image to sandbox does not change title after it is finished', async () => {
   vi.mocked(got).mockImplementation(
     // use vi.fn(), so there is no need to deal with types safety when mocking

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,8 +212,11 @@ export async function getDevSandboxSignUpStatus(idToken: string): Promise<SBSign
   return status;
 }
 
+let deactivated = false; // flag to prevent setting timeout after deactivation
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   console.log('starting extension redhat-developer-sandbox');
+  deactivated = false; // reset for tests to work correctly
 
   let status: extensionApi.ProviderStatus = 'ready';
   const icon = './icon.png';
@@ -331,12 +334,15 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
 function updateConnectionsPeriodically(): void {
   updateConnections().then(() => {
-    updateConnectionTimeout = setTimeout(updateConnectionsPeriodically, 2000);
+    if (!deactivated) {
+      updateConnectionTimeout = setTimeout(updateConnectionsPeriodically, 2000);
+    }
   });
 }
 
 export function deactivate(): void {
   console.log('deactivating redhat-developer-sandbox extension');
+  deactivated = true;
   if (updateConnectionTimeout) {
     clearTimeout(updateConnectionTimeout);
   }


### PR DESCRIPTION
Closes #120.

Fix introduces `deactivated` boolean variable to pass extension status to updateConnectionsPeriodically() function to avoid setting timer after extension deactivation when promise returned from function above resolves after deactivate() call.

https://github.com/user-attachments/assets/79ba94e7-8c77-46d6-af72-168bc0ad098a


Assisted-by: <Cursor>