### PR TITLE
fix: introduce timeout for waiting pipeline service account provision

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
           "minimum": 1,
           "default": 8,
           "description": "Developer Sandbox availability check interval (seconds)"
+        },
+        "redhat.sandbox.serviceAccountProvisionMaxWaitTime" : {
+          "type": "number",
+          "minimum": 60,
+          "default": 180,
+          "description": "Developer Sandbox Service Account Provision Max Wait Time (seconds)"
         }
       }
     },

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -59,12 +59,30 @@ vi.mock(import('./sandbox.js'), async importOriginal => {
     signUp: vi.fn(),
     getRegistrationServiceTimeout: vi.fn(),
     getAvailabilityCheckInterval: vi.fn().mockReturnValue(8000),
+    getServiceAccountProvisionMaxWaitTime: vi.fn(),
   };
 });
 
 vi.mock(import('./utils.js'), () => {
+  const delay = vi.fn().mockResolvedValue(undefined);
   return {
-    delay: vi.fn().mockResolvedValue(undefined),
+    delay,
+    waitFor: async <T>(
+      action: () => Promise<T | undefined>,
+      maxWaitTimeMs: number,
+      pollIntervalMs = 250,
+    ): Promise<T | undefined> => {
+      let elapsedMs = 0;
+      while (elapsedMs < maxWaitTimeMs) {
+        const result = await action();
+        if (result !== undefined) {
+          return result;
+        }
+        await delay(pollIntervalMs);
+        elapsedMs += pollIntervalMs;
+      }
+      return undefined;
+    },
   };
 });
 
@@ -375,6 +393,7 @@ suite('kubernetes provider connection factory', () => {
       const config = new KubeConfig();
       const sandboxAPIMock = () => {
         vi.mocked(sandbox.getRegistrationServiceTimeout).mockReturnValue(30000);
+        vi.mocked(sandbox.getServiceAccountProvisionMaxWaitTime).mockReturnValue(30000);
         vi.mocked(sandbox.getSignUpStatus).mockResolvedValue({
           apiEndpoint: 'https//:sandbox-host-url',
           username: 'username',
@@ -386,15 +405,11 @@ suite('kubernetes provider connection factory', () => {
         vi.mocked(sandbox.signUp).mockResolvedValueOnce();
       };
       const getTokenMock = () => {
-        vi.spyOn(CoreV1Api.prototype, 'listNamespacedServiceAccount').mockResolvedValue({
-          items: [
-            {
-              metadata: {
-                name: 'pipeline',
-                uid: 'unique-id1',
-              },
-            },
-          ],
+        vi.spyOn(CoreV1Api.prototype, 'readNamespacedServiceAccount').mockResolvedValue({
+          metadata: {
+            name: 'pipeline',
+            uid: 'unique-id1',
+          },
         });
         vi.spyOn(CoreV1Api.prototype, 'createNamespacedSecret').mockResolvedValue({} as V1Secret);
         const responseError: any = new Error();

--- a/src/openshift.spec.ts
+++ b/src/openshift.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { CoreV1Api } from '@kubernetes/client-node';
+import * as sandbox from './sandbox.js';
+import { getPipelineServiceAccountToken } from './openshift.js';
+
+vi.mock(import('./sandbox.js'), async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    getServiceAccountProvisionMaxWaitTime: vi.fn(),
+    getRegistrationServiceTimeout: vi.fn(),
+  };
+});
+
+describe('getPipelineServiceAccountToken', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('polls for pipeline service account and times out after max wait time', async () => {
+    const pollIntervalMs = 250;
+    const timeoutMs = pollIntervalMs * 3;
+    vi.mocked(sandbox.getServiceAccountProvisionMaxWaitTime).mockReturnValue(timeoutMs);
+
+    const readSpy = vi
+      .spyOn(CoreV1Api.prototype, 'readNamespacedServiceAccount')
+      .mockRejectedValue(new Error('NotFound'));
+
+    const promise = getPipelineServiceAccountToken('https://proxy.example.com', 'username', 'id-token');
+    const expectation = expect(promise).rejects.toThrow(
+      `Timed out waiting for 'pipeline' service account to appear in namespace 'username-dev'.`,
+    );
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(sandbox.getServiceAccountProvisionMaxWaitTime).toHaveBeenCalledOnce();
+    expect(readSpy).toHaveBeenCalledTimes(3);
+    expect(readSpy).toHaveBeenCalledWith({
+      name: 'pipeline',
+      namespace: 'username-dev',
+    });
+  });
+});

--- a/src/openshift.ts
+++ b/src/openshift.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import got from 'got';
 import * as kubeconfig from './kubeconfig.js';
 import * as extensionApi from '@podman-desktop/api';
 import { CoreV1Api, KubeConfig, V1Secret, V1ServiceAccount } from '@kubernetes/client-node';
-import { getRegistrationServiceTimeout } from './sandbox.js';
-import { delay } from './utils.js';
+import { getRegistrationServiceTimeout, getServiceAccountProvisionMaxWaitTime } from './sandbox.js';
+import { waitFor } from './utils.js';
 
 export interface InternalRegistryInfo {
   host: string;
@@ -145,26 +145,22 @@ async function installPipelineSecretToken(
   } as V1Secret;
 
   await k8sApi.createNamespacedSecret({ namespace: `${username}-dev`, body: v1Secret });
-  const timeout = getRegistrationServiceTimeout();
-  const startTime = Date.now();
-  while (Date.now() - startTime < timeout) {
+  return waitFor(async () => {
     try {
-      const response = await k8sApi.readNamespacedSecret({
+      return await k8sApi.readNamespacedSecret({
         name: secretName,
         namespace: `${username}-dev`,
       });
-      return response;
     } catch (error) {
       const err = error as { response?: { statusCode?: number } };
       if (err.response?.statusCode === 404) {
         console.error(`Cannot read created sandbox secret ${secretName}`);
-        await delay(250);
-      } else {
-        console.error(String(error));
-        throw error;
+        return undefined;
       }
+      console.error(String(error));
+      throw error;
     }
-  }
+  }, getRegistrationServiceTimeout());
 }
 
 export async function getPipelineServiceAccountToken(
@@ -174,12 +170,21 @@ export async function getPipelineServiceAccountToken(
 ): Promise<string> {
   const kcu = prepareKubeConfig('sandbox-proxy', 'sso-user', 'sandbox-proxy-context', proxy, username, idToken);
   const k8sApi = kcu.makeApiClient(CoreV1Api);
-  const serviceAccounts = await k8sApi.listNamespacedServiceAccount({ namespace: `${username}-dev` });
-  const pipelineServiceAccount = serviceAccounts.items.find(
-    serviceAccount => serviceAccount.metadata?.name === 'pipeline',
-  ) as V1ServiceAccount | undefined;
+  const pipelineServiceAccount = await waitFor(async () => {
+    try {
+      return await k8sApi.readNamespacedServiceAccount({
+        name: 'pipeline',
+        namespace: `${username}-dev`,
+      });
+    } catch (error) {
+      // ignore error, continue polling
+      console.error('Error while polling for service accounts: ' + String(error));
+      return undefined;
+    }
+  }, getServiceAccountProvisionMaxWaitTime());
+
   if (!pipelineServiceAccount) {
-    throw new Error(`Couldn't find service account required to create Developer Sandbox connection.`);
+    throw new Error(`Timed out waiting for 'pipeline' service account to appear in namespace '${username}-dev'.`);
   }
 
   const secrets = await k8sApi.listNamespacedSecret({ namespace: `${username}-dev` });

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -68,6 +68,10 @@ export function getAvailabilityCheckInterval(): number {
   return configuration.getConfiguration('redhat').get<number>('sandbox.availabilityCheckInterval', 8) * 1000;
 }
 
+export function getServiceAccountProvisionMaxWaitTime(): number {
+  return configuration.getConfiguration('redhat').get<number>('sandbox.serviceAccountProvisionMaxWaitTime', 180) * 1000;
+}
+
 function createSandboxAPITimeout(): Delays {
   return {
     response: getRegistrationServiceTimeout(),

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { waitFor } from './utils.js';
+
+describe('waitFor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('returns value when action succeeds on first attempt', async () => {
+    const action = vi.fn().mockResolvedValue('ready');
+
+    await expect(waitFor(action, 750)).resolves.toBe('ready');
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  test('polls until action returns a value', async () => {
+    const action = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce('ready');
+
+    const promise = waitFor(action, 750, 250);
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toBe('ready');
+    expect(action).toHaveBeenCalledTimes(3);
+  });
+
+  test('returns undefined when max wait time elapses', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+
+    const promise = waitFor(action, 750, 250);
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(action).toHaveBeenCalledTimes(3);
+  });
+
+  test('propagates errors from action immediately', async () => {
+    const error = new Error('boom');
+    const action = vi.fn().mockRejectedValue(error);
+
+    await expect(waitFor(action, 750, 250)).rejects.toThrow(error);
+    expect(action).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,4 +20,26 @@ import { setTimeout } from 'timers/promises';
 
 export async function delay(interval: number): Promise<void> {
   await setTimeout(interval);
+}
+
+/**
+ * Polls `action` until it returns a defined value or `maxWaitTimeMs` elapses.
+ * Return `undefined` from `action` to keep waiting. Thrown errors propagate immediately.
+ */
+export async function waitFor<T>(
+  action: () => Promise<T | undefined>,
+  maxWaitTimeMs: number,
+  pollIntervalMs = 250,
+): Promise<T | undefined> {
+  let now = Date.now();
+  const deadline = now + maxWaitTimeMs;
+  while (now < deadline) {
+    const result = await action();
+    if (result !== undefined) {
+      return result;
+    }
+    await delay(pollIntervalMs);
+    now += pollIntervalMs;
+  }
+  return undefined;
 }


### PR DESCRIPTION
When trial starts for Developer Sandbox, not every resource is being created right away. Pipeline service account used to configure kubernetes context appears approximately withing 3 minutes after cluster is created.

This fix introduces cycle to check if pipeline service account is created and only then proceeds with creating kubernetes context for Developer Sandbox cluster.

Closes #784.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>