### PR TITLE
fix: introduce availability check interval setting for cheking sandbox connection status

### DIFF
--- a/__mocks__/@podman-desktop/api.js
+++ b/__mocks__/@podman-desktop/api.js
@@ -44,6 +44,12 @@ module.exports = {
     getKubeconfig: vi.fn(),
   },
 
+  configuration: {
+    getConfiguration: vi.fn().mockReturnValue({
+      get: vi.fn((_key, defaultValue) => defaultValue),
+    }),
+  },
+
   env: {
     createTelemetryLogger: () => {
       return {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
           "minimum": 0,
           "default": "30",
           "description": "Developer Sandbox Registration Service timeout (seconds)"
+        },
+        "redhat.sandbox.availabilityCheckInterval": {
+          "type": "number",
+          "minimum": 1,
+          "default": 8,
+          "description": "Developer Sandbox availability check interval (seconds)"
         }
       }
     },

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -58,6 +58,7 @@ vi.mock(import('./sandbox.js'), async importOriginal => {
     getSignUpStatus: vi.fn(),
     signUp: vi.fn(),
     getRegistrationServiceTimeout: vi.fn(),
+    getAvailabilityCheckInterval: vi.fn().mockReturnValue(8000),
   };
 });
 
@@ -488,6 +489,30 @@ describe('deactivation stops periodic connection updates', () => {
     await vi.advanceTimersByTimeAsync(10000);
 
     expect(createOrLoadSpy).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('uses availability check interval for periodic connection updates', async () => {
+    vi.useFakeTimers();
+    const intervalMs = 5000;
+    vi.mocked(sandbox.getAvailabilityCheckInterval).mockReturnValue(intervalMs);
+    setupActivation();
+    await extension.activate(context);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sandbox.getAvailabilityCheckInterval).toHaveBeenCalled();
+
+    const createOrLoadSpy = vi.mocked(kubeconfig.createOrLoadFromFile);
+    createOrLoadSpy.mockClear();
+
+    await vi.advanceTimersByTimeAsync(intervalMs - 1);
+    expect(createOrLoadSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(createOrLoadSpy).toHaveBeenCalled();
+
+    extension.deactivate();
     vi.useRealTimers();
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import * as extensionApi from '@podman-desktop/api';
 import got from 'got';
 import * as kubeconfig from './kubeconfig.js';
 import { getOpenShiftInternalRegistryPublicHost, getPipelineServiceAccountToken } from './openshift.js';
-import { getSignUpStatus, SBSignupResponse, signUp } from './sandbox.js';
+import { getAvailabilityCheckInterval, getSignUpStatus, SBSignupResponse, signUp } from './sandbox.js';
 
 const ProvideDisplayName = 'Developer Sandbox';
 
@@ -385,7 +385,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 function updateConnectionsPeriodically(): void {
   updateConnections().then(() => {
     if (!deactivated) {
-      updateConnectionTimeout = setTimeout(updateConnectionsPeriodically, 2000);
+      updateConnectionTimeout = setTimeout(updateConnectionsPeriodically, getAvailabilityCheckInterval());
     }
   });
 }

--- a/src/sandbox.spec.ts
+++ b/src/sandbox.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import * as podmanDesktopApi from '@podman-desktop/api';
+import { getAvailabilityCheckInterval } from './sandbox.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('getAvailabilityCheckInterval returns configured value in milliseconds', () => {
+  const get = vi.fn().mockReturnValue(12);
+  vi.mocked(podmanDesktopApi.configuration.getConfiguration).mockReturnValue({ get } as never);
+
+  expect(getAvailabilityCheckInterval()).toBe(12000);
+  expect(podmanDesktopApi.configuration.getConfiguration).toHaveBeenCalledWith('redhat');
+  expect(get).toHaveBeenCalledWith('sandbox.availabilityCheckInterval', 8);
+});
+
+test('getAvailabilityCheckInterval uses default of 8 seconds when unset', () => {
+  const get = vi.fn().mockImplementation((_key: string, defaultValue: number) => defaultValue);
+  vi.mocked(podmanDesktopApi.configuration.getConfiguration).mockReturnValue({ get } as never);
+
+  expect(getAvailabilityCheckInterval()).toBe(8000);
+});

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -64,6 +64,10 @@ export function getRegistrationServiceTimeout(): number {
   return configuration.getConfiguration('redhat').get<number>('sandbox.registrationServiceTimeout', 30) * 1000;
 }
 
+export function getAvailabilityCheckInterval(): number {
+  return configuration.getConfiguration('redhat').get<number>('sandbox.availabilityCheckInterval', 8) * 1000;
+}
+
 function createSandboxAPITimeout(): Delays {
   return {
     response: getRegistrationServiceTimeout(),


### PR DESCRIPTION
Fix introduces configurable interval with default value 8s, similar to podman desktop provider status check.

Closes #93.

